### PR TITLE
2 new endpoints to gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN opentelemetry-bootstrap -a install
 
 COPY . /usr/src/app
 
+
 RUN mkdir ./swagger_server/swagger_downloaded
 RUN mkdir ./swagger_server/swagger_generated
 

--- a/swagger_server/__main__.py
+++ b/swagger_server/__main__.py
@@ -13,7 +13,7 @@ import requests
 from flask_cors import CORS
 import sys
 
-
+from swagger_server.controllers.feedback_controller import submit_feedback
 from swagger_server.controllers import routing_request
 from connexion.decorators.response import ResponseValidator
 from swagger_server.custom_validators import CustomParameterValidator, CustomRequestBodyValidator
@@ -71,6 +71,7 @@ sharing_api_setup = getenv_split('LOAD_SHARING_API')
 converter_api_setup = getenv_split('LOAD_CONVERTER_API')
 monitoring_api_setup = getenv_split('LOAD_MONITORING_API')
 email_sender_api_setup = getenv_split('LOAD_EMAIL_SENDER_API')
+submit_feedback_api_setup = getenv_split('LOAD_SUBMIT_FEEDBACK_API')
 
 class ReverseProxied(object):
     '''Wrap the application in this middleware and configure the
@@ -175,50 +176,60 @@ def manipulate_and_generate_yaml(json_loaded, filename, service, host, isauth: b
             json_loaded['paths'][key]['get']['x-openapi-router-controller'] = "swagger_server.controllers.dynamic_controller"
         else:
             if 'get' in json_loaded['paths'][key]:
-                randomname = ''.join(random.choice(string.ascii_lowercase) for _ in range(30))
-                if "monitoring" in key and monitoring_api_setup:
-                    add_method_to_dynamic_controller(
-                        randomname,
-                        host,
-                        service,
-                        monitoring_api_setup[0],
-                        monitoring_api_setup[1],
-                    )
-                else:
-                    if 'get' in value and 'parameters' in value['get'] and isinstance(value['get']['parameters'], list) and len(value['get']['parameters']) > 0 and 'in' in value['get']['parameters'][0] and 'name' in value['get']['parameters'][0] and value['get']['parameters'][0]['in'] == 'path':
-                        add_method_to_dynamic_controller(randomname, host, service, isauth, only_admin)
-                    else :
-                        add_method_to_dynamic_controller(randomname, host, service, isauth, only_admin)
-                json_loaded['paths'][key]['get']['operationId'] = randomname
-                json_loaded['paths'][key]['get']['x-openapi-router-controller'] = "swagger_server.controllers.dynamic_controller"
-                if isauth or ("monitoring" in key and monitoring_api_setup and monitoring_api_setup[0]):
-                    json_loaded['paths'][key]['get'].update(security_dict)
-            if 'options' in json_loaded['paths'][key]:
-                randomname = ''.join(random.choice(string.ascii_lowercase) for _ in range(30))
-                if "monitoring" in key and monitoring_api_setup:
-                    add_method_to_dynamic_controller(
-                        randomname,
-                        host,
-                        service,
-                        monitoring_api_setup[0],
-                        monitoring_api_setup[1],
-                    )
-                else:
-                    if 'options' in value and 'parameters' in value['options'] and isinstance(value['options']['parameters'], list) and len(value['options']['parameters']) > 0 and 'in' in value['get']['parameters'][0] and 'name' in value['options']['parameters'][0] and value['options']['parameters'][0]['in'] == 'path':
-                        add_method_to_dynamic_controller(randomname,host,service,isauth, only_admin)
-                    else :
-                        add_method_to_dynamic_controller(randomname,host,service,isauth, only_admin)
-                json_loaded['paths'][key]['options']['operationId'] = randomname
-                json_loaded['paths'][key]['options']['x-openapi-router-controller'] = "swagger_server.controllers.dynamic_controller"
-                if isauth or ("monitoring" in key and monitoring_api_setup and monitoring_api_setup[0]):
-                    json_loaded['paths'][key]['options'].update(security_dict)
+                if service == "/statistics":
+                    path = "/statistics"
+                    json_loaded['paths'][key]['get']['operationId'] = "statistics_fetcher"
+                    json_loaded['paths'][key]['get']['x-openapi-router-controller'] = "swagger_server.statistics_fetcher"
+                else:    
+                    randomname = ''.join(random.choice(string.ascii_lowercase) for _ in range(30))
+                    if "monitoring" in key and monitoring_api_setup:
+                        add_method_to_dynamic_controller(
+                            randomname,
+                            host,
+                            service,
+                            monitoring_api_setup[0],
+                            monitoring_api_setup[1],
+                        )
+                    else:
+                        if 'get' in value and 'parameters' in value['get'] and isinstance(value['get']['parameters'], list) and len(value['get']['parameters']) > 0 and 'in' in value['get']['parameters'][0] and 'name' in value['get']['parameters'][0] and value['get']['parameters'][0]['in'] == 'path':
+                            add_method_to_dynamic_controller(randomname, host, service, isauth, only_admin)
+                        else :
+                            add_method_to_dynamic_controller(randomname, host, service, isauth, only_admin)
+                    json_loaded['paths'][key]['get']['operationId'] = randomname
+                    json_loaded['paths'][key]['get']['x-openapi-router-controller'] = "swagger_server.controllers.dynamic_controller"
+                    if isauth or ("monitoring" in key and monitoring_api_setup and monitoring_api_setup[0]):
+                        json_loaded['paths'][key]['get'].update(security_dict)
+                if 'options' in json_loaded['paths'][key]:
+                    randomname = ''.join(random.choice(string.ascii_lowercase) for _ in range(30))
+                    if "monitoring" in key and monitoring_api_setup:
+                        add_method_to_dynamic_controller(
+                            randomname,
+                            host,
+                            service,
+                            monitoring_api_setup[0],
+                            monitoring_api_setup[1],
+                        )
+                    else:
+                        if 'options' in value and 'parameters' in value['options'] and isinstance(value['options']['parameters'], list) and len(value['options']['parameters']) > 0 and 'in' in value['get']['parameters'][0] and 'name' in value['options']['parameters'][0] and value['options']['parameters'][0]['in'] == 'path':
+                            add_method_to_dynamic_controller(randomname,host,service,isauth, only_admin)
+                        else :
+                            add_method_to_dynamic_controller(randomname,host,service,isauth, only_admin)
+                    json_loaded['paths'][key]['options']['operationId'] = randomname
+                    json_loaded['paths'][key]['options']['x-openapi-router-controller'] = "swagger_server.controllers.dynamic_controller"
+                    if isauth or ("monitoring" in key and monitoring_api_setup and monitoring_api_setup[0]):
+                        json_loaded['paths'][key]['options'].update(security_dict)
             if 'post' in json_loaded['paths'][key]:
-                randomname = ''.join(random.choice(string.ascii_lowercase) for _ in range(30))
-                add_method_to_dynamic_controller(randomname,host,service,isauth, only_admin)
-                json_loaded['paths'][key]['post']['operationId'] = randomname
-                json_loaded['paths'][key]['post']['x-openapi-router-controller'] = "swagger_server.controllers.dynamic_controller"
-                if isauth :
-                    json_loaded['paths'][key]['post'].update(security_dict)
+                if service == "/submit_feedback":
+                    path = "/submit_feedback"
+                    json_loaded['paths'][path]['post']['operationId'] = "submit_feedback"
+                    json_loaded['paths'][path]['post']['x-openapi-router-controller'] = "swagger_server.controllers.feedback_controller"
+                else:
+                    randomname = ''.join(random.choice(string.ascii_lowercase) for _ in range(30))
+                    add_method_to_dynamic_controller(randomname,host,service,isauth, only_admin)
+                    json_loaded['paths'][key]['post']['operationId'] = randomname
+                    json_loaded['paths'][key]['post']['x-openapi-router-controller'] = "swagger_server.controllers.dynamic_controller"
+                    if isauth :
+                        json_loaded['paths'][key]['post'].update(security_dict)
             if 'put' in json_loaded['paths'][key]:
                 randomname = ''.join(random.choice(string.ascii_lowercase) for _ in range(30))
                 if 'put' in value and 'parameters' in value['put'] and isinstance(value['put']['parameters'],list) and len(value['put']['parameters']) > 0 and 'in' in value['put']['parameters'][0] and 'name' in value['put']['parameters'][0] and value['put']['parameters'][0]['in'] == 'path':
@@ -399,6 +410,23 @@ def load_configuration():
             logging.error("Error executing fetch of sharing host")
             traceback.print_exc()
             sys.exit()
+
+   # adds the feedback_services partial to the list of yamls to be merged 
+    try:
+            
+        conf_array.append(open("./swagger_server/swagger_partial/feedback_services.yaml", "r", encoding="utf-8").read())
+    except:
+            logging.error("Error executing fetch of feedback yaml")
+            traceback.print_exc()
+            sys.exit()
+    # adds the statistics_fetcher partial to the list of yamls to be merged
+    try:   
+        conf_array.append(open("./swagger_server/swagger_partial/statistics_fetcher.yaml", "r", encoding="utf-8").read())
+    except:
+            logging.error("Error executing fetch of statistcs yaml")
+            traceback.print_exc()
+            sys.exit()
+
 
 
     # ADD Security component

--- a/swagger_server/controllers/feedback_controller.py
+++ b/swagger_server/controllers/feedback_controller.py
@@ -1,0 +1,60 @@
+import os
+import requests
+from flask import request, Response
+import logging
+
+logger = logging.getLogger(__name__)
+
+def submit_feedback():
+    try:
+        # Get configuration
+        feedback_destination = os.getenv("FEEDBACK_DESTINATION_URL")
+        feedback_token = os.getenv("FEEDBACK_TOKEN")
+
+        # Validate environment variables
+        if not feedback_destination:
+            logger.error("FEEDBACK_DESTINATION_URL environment variable is not set")
+            return Response('{"error": "Feedback service not configured, "}', status=500, content_type='application/json')
+        
+        if not feedback_token:
+            logger.error("FEEDBACK_TOKEN environment variable is not set")
+            return Response('{"error": "Feedback authentication not configured"}', status=500, content_type='application/json')
+        # Validate request
+        if not request.is_json:
+            return Response('{"error": "Request must be JSON"}', status=400, content_type='application/json')
+
+        body = request.get_json()
+        
+        # Validate required fields (optional but recommended)
+        if not body or 'title' not in body:
+            return Response('{"error": "Missing title field"}', status=400, content_type='application/json')
+
+        # Prepare headers
+        headers = {
+            "PRIVATE-TOKEN": feedback_token,
+            "Content-Type": "application/json"
+        }
+
+        logger.info(f"Submitting feedback to: {feedback_destination}")
+        
+  
+        feedback_request = requests.post(
+            feedback_destination, 
+            headers=headers, 
+            json=body,
+        )
+
+        return Response(
+            feedback_request.content, 
+            feedback_request.status_code, 
+            content_type=feedback_request.headers.get("Content-Type", "application/json")
+        )
+    except requests.exceptions.ConnectionError:
+        logger.error("Cannot connect to feedback service")
+        return Response('{"error": "Cannot connect to feedback service"}', status=503, content_type='application/json')
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Feedback request failed: {str(e)}")
+        return Response('{"error": "Failed to submit feedback"}', status=500, content_type='application/json')
+    except Exception as e:
+        logger.error(f"Unexpected error in submit_feedback: {str(e)}")
+        return Response('{"error": "Internal server error"}', status=500, content_type='application/json')

--- a/swagger_server/statistics_fetcher.py
+++ b/swagger_server/statistics_fetcher.py
@@ -1,0 +1,23 @@
+import requests
+from flask import request, Response
+import os
+
+def statistics_fetcher():
+    statistic_base_url = os.getenv("BRGM_BASE_URL")
+    statistic_token = os.getenv("BRGM_TOKEN")
+    #get query string from request
+    query_string = request.query_string.decode("utf-8")
+    #checks
+    if not query_string:
+        return {"error": "No query parameters provided"}, 400
+    
+    # build full url
+    full_url = f"{statistic_base_url}?{query_string}&token_auth={statistic_token}"
+    
+    try:
+        # Forward the request to BRGM
+        resp = requests.get(full_url)
+        # Return the response content and status code directly
+        return Response(resp.content, status=resp.status_code, content_type=resp.headers.get("Content-Type", "application/json"))
+    except requests.RequestException as e:
+        return {"error": str(e)}, 500

--- a/swagger_server/swagger_partial/feedback_services.yaml
+++ b/swagger_server/swagger_partial/feedback_services.yaml
@@ -1,0 +1,76 @@
+paths:
+  /submit_feedback:
+    post:
+      description: Submit feedback as a GitLab issue with title, description, and labels
+      tags:
+        - Feedback
+      summary: Submit feedback to GitLab
+      operationId: submit_feedback
+      x-openapi-router-controller: swagger_server.controllers.feedback_controller
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                  description: Title of the issue/feedback
+                  example: "Bug Report: Botton not working"
+                description:
+                  type: string
+                  description: Info about the sender, and detailed information about the problem
+                  example: "name: alessandro \naffiliation:ingv \nemail:alessandro.crocetta@ingv.it \nmessage:Button not working"
+                labels:
+                  type: string
+                  items:
+                    type: string
+                  description: Labels for categorizing the issue
+                  example: "Triage, Bugreport"
+              required:
+                - title
+                - description
+      responses:
+        '201':
+          description: Feedback submitted successfully
+        
+                
+        '400':
+          description: Missing required parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/main.HTTPError'
+        '500':
+          description: Error submitting feedback to GitLab
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/main.HTTPError'
+
+components:
+  schemas:
+    main.HTTPError:
+      type: object
+      properties:
+        error:
+          type: string
+          example: "Missing required parameter: title"
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          
+          

--- a/swagger_server/swagger_partial/statistics_fetcher.yaml
+++ b/swagger_server/swagger_partial/statistics_fetcher.yaml
@@ -1,0 +1,79 @@
+paths:
+  /statistics:
+    get:
+      description: Fetches the statistics from the BRGM statistics service
+      tags:
+        - Statistics
+      summary: GET statistics
+      operationId: statistics_fetcher
+      x-openapi-router-controller: swagger_server.statistics_fetcher
+      parameters:
+        - name: module
+          in: query
+          required: false
+          schema:
+            type: string
+          example: Widgetize
+        - name: action
+          in: query
+          required: false
+          schema:
+            type: string
+          example: iframe
+        - name: disableLink
+          in: query
+          required: false
+          schema:
+            type: integer
+          example: 1
+        - name: widget
+          in: query
+          required: false
+          schema:
+            type: integer
+          example: 1
+        - name: moduleToWidgetize
+          in: query
+          required: false
+          schema:
+            type: string
+          example: UserCountryMap
+        - name: actionToWidgetize
+          in: query
+          required: false
+          schema:
+            type: string
+          example: visitorMap
+        - name: idSite
+          in: query
+          required: false
+          schema:
+            type: integer
+          example: 233
+        - name: period
+          in: query
+          required: false
+          schema:
+            type: string
+          example: range
+        - name: date
+          in: query
+          required: false
+          schema:
+            type: string
+          example: 2019-01-1,today
+        - name: language
+          in: query
+          required: false
+          schema:
+            type: string
+          example: en
+        - name: enableDatePicker
+          in: query
+          required: false
+          schema:
+            type: integer
+          example: 1
+      responses:
+        '200':
+          description: Successfully Found


### PR DESCRIPTION
This pull request adds 2 new endpoints /submit_feedback and /statistics.
This branch adds 2 new python files and 2 yaml files:
1) feedback_controller.py that stores the function that makes the post request the gitlab and feedback_services.yaml to add the function on the swagger page 
2)statistic_fetcher.py that stores the function that makes the get request to matomo and statistics_fetcher.yaml to add the function on the swagger page.
There are a few small changes in manipulate_and_generate_yaml just so that in case one of the 2 endpoints are called it will direct the program to the relative function otherwise it will work as it always has.
This branch solves the issue that the secrete private token to the underlying microservices results visible, since the calls are hardcoded in the GUI. It solves it by avoiding that the GUI makes the calls to matomo and gitlab directly, instead it passes the call first to the gateway which then adds the private token and then send the request to matomo or gitlab.