### PR TITLE
fix posts with body not json not working

### DIFF
--- a/swagger_server/controllers/dynamic_controller.py
+++ b/swagger_server/controllers/dynamic_controller.py
@@ -60,7 +60,7 @@ def call_redirect(query, isauthrequest, server, only_admin: bool = False):
                             connexion.request.method, 
                             connexion.request.headers, 
                             query,
-                            connexion.request.form,
+                            connexion.request.get_data(),
                             connexion.request)
 
 def tcsconnections_ogc_execute_get_using_get(instance_id=None):  # noqa: E501

--- a/swagger_server/controllers/routing_request.py
+++ b/swagger_server/controllers/routing_request.py
@@ -58,7 +58,6 @@ def authorizationJWT(bearer_token):
         return Response("TOKEN NOT VALID", 401)
 
 def routingrequest(server, method, headers, query, body, request):
-
     logging.warning('Executing the actual request with the following parameters: ')
     logging.warning('[server]:\n'+str(server)+'\n')
     logging.warning('[method]:\n'+str(method)+'\n')
@@ -87,12 +86,12 @@ def routingrequest(server, method, headers, query, body, request):
         if request.is_json:
             resp = requests.post(f'{server}?{query}', json=request.json, headers=headers, allow_redirects=False)
         else:
-            resp = requests.post(f'{server}?{query}', json=body, headers=headers, allow_redirects=False)
+            resp = requests.post(f'{server}?{query}', data=body, headers=headers, allow_redirects=False)
     if method == 'PUT' :
         if request.is_json:
             resp = requests.put(f'{server}?{query}', json=request.json, headers=headers, allow_redirects=False)
         else:
-            resp = requests.put(f'{server}?{query}', json=body, headers=headers, allow_redirects=False)
+            resp = requests.put(f'{server}?{query}', data=body, headers=headers, allow_redirects=False)
     if method == 'DELETE' :
         resp = requests.delete(f'{server}?{query}', data=body, headers=headers, allow_redirects=False)
 


### PR DESCRIPTION
posts to endpoints that accepted a body not in json didn't work before because the body was passed as a json body even when it wasn't.
this fixes that and also uses the `get_data` connexion function to get the body of a request instead of the `form` attribute since sometimes that is empty even with posts with bodies.